### PR TITLE
qute: revision for boost bumping from 1.66.0 to 1.70.0

### DIFF
--- a/qute.rb
+++ b/qute.rb
@@ -4,7 +4,7 @@ class Qute < Formula
   url "https://github.com/maelvalais/qute/archive/v0.0.1.tar.gz"
   sha256 "488825160ac586df7c0c642fff673731ba82647defa12941acde93bcf503a7d8"
   head "https://github.com/maelvalais/qute.git"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://dl.bintray.com/touist/bottles-touist"


### PR DESCRIPTION
Error was:

/home/linuxbrew/.linuxbrew/Cellar/qute/0.0.1_2/bin/qute: error while
loading shared libraries: libboost_program_options-mt.so.1.66.0: cannot
open shared object file: No such file or directory