### PR TITLE
rareqs: linux needs a new bottle (glibc broken)

### DIFF
--- a/qute.rb
+++ b/qute.rb
@@ -17,7 +17,10 @@ class Qute < Formula
   depends_on "boost"
   depends_on "cmake" => :build
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "cmake", ".", *std_cmake_args
     system "make"
     bin.install "qute"

--- a/qute.rb
+++ b/qute.rb
@@ -4,7 +4,7 @@ class Qute < Formula
   url "https://github.com/maelvalais/qute/archive/v0.0.1.tar.gz"
   sha256 "488825160ac586df7c0c642fff673731ba82647defa12941acde93bcf503a7d8"
   head "https://github.com/maelvalais/qute.git"
-  revision 3
+  revision 4
 
   bottle do
     root_url "https://dl.bintray.com/touist/bottles-touist"

--- a/rareqs.rb
+++ b/rareqs.rb
@@ -3,7 +3,7 @@ class Rareqs < Formula
   homepage "http://sat.inesc-id.pt/~mikolas/sw/areqs/"
   url "http://sat.inesc-id.pt/~mikolas/sw/areqs/rareqs-1.1.src.tgz"
   sha256 "2d58097594e813036be922cb5914e6ba659e4bd424336dc7ed917d6c9191e2a3"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://dl.bintray.com/touist/bottles-touist"

--- a/rareqs.rb
+++ b/rareqs.rb
@@ -5,6 +5,8 @@ class Rareqs < Formula
   sha256 "2d58097594e813036be922cb5914e6ba659e4bd424336dc7ed917d6c9191e2a3"
   revision 2
 
+  depends_on "zlib" unless OS.mac?
+
   bottle do
     root_url "https://dl.bintray.com/touist/bottles-touist"
     cellar :any_skip_relocation


### PR DESCRIPTION

The errors on `qute` and `rareqs` looked like:
```
/home/linuxbrew/.linuxbrew/Cellar/qute/0.0.1_3/bin/qute: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /home/linuxbrew/.linuxbrew/Cellar/qute/0.0.1_3/bin/qute)
```

After some digging, I found out that this issue is related to the change of C++ ABI (from gcc 4.8.x to >=5.1 which has [dual-ABI] stuff, the problem with this is documented on [SO](https://stackoverflow.com/questions/47149139/relationship-between-glibcxxlibstdc-so-6-and-gcc-version#answer-47149524)). 

The Travis CI Ubuntu trusty image says it has glibc 2.19. It is the minimum [requirement] for installing bottles using linuxbrew as of July 2018. Here is the glibc version on the travis image:

[dual-ABI]: https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
[requirement]: https://github.com/Linuxbrew/brew/commit/400af242fd7252edc461dba473961097507eed48#diff-04c6e90faac2675aa89e2176d2eec7d8

```
travis@12c27ad0d2d7:/$ ldd --version
ldd (Ubuntu EGLIBC 2.19-0ubuntu6.13) 2.19
Copyright (C) 2014 Free Software Foundation, Inc.
```

Recently, all the libraries in Linuxbrew have been rebuilt using the newer C++ ABI (using gcc >= 5.1). In my case, system gcc has version 4.8.4. Which means whenever I want to build anything linking to  glibcxx.so, I will have to do it using gcc5...

And the workaround for now is to use the `needs :cxx11` which will force the use of gcc >= 5 and that will also install glibc.


So I enabled building using cxx11 standard.