### PR TITLE
Fix boost update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,21 @@
 #   and the bottles are pushed to bintray as 'unpublished'. The DSL commit
 #   is pushed as a tag, e.g., 'pr-1234', which us unrelated to master.
 
-language: ruby
 if: tag IS blank AND NOT type IN (push)
 env:
   global:
     - HOMEBREW_LOGS=/tmp # Prevent ~/.cache/Homebrew/Logs from being rebuilt
     - HOMEBREW_NO_AUTO_UPDATE=yes # Prevents redundant auto-updates from brew
+    - HOMEBREW_AZURE_PIPELINES=1
 
     ###### Bintray configuration ######
-    - TAP_BOTTLE_ORG=touist                # Used in this script only
+    - TAP_BOTTLE_ORG=touist # Used in this script only
     - TAP_BOTTLE_ROOT_URL=https://dl.bintray.com/$TAP_BOTTLE_ORG/bottles-touist
     - HOMEBREW_BINTRAY_USER=maelvalais
     # HOMEBREW_BINTRAY_KEY                 # Secret variable set in Travis CI
 
     ###### AWS S3 configuration ######
-    - AWS_REGION=eu-west-1                 # aws-sdk-s3 gem errors without it
+    - AWS_REGION=eu-west-1 # aws-sdk-s3 gem errors without it
     - BUCKET=homebrew-touist-travis
     # AWS_ACCESS_KEY_ID                    # Secret variable set in Travis CI
     # AWS_SECRET_ACCESS_KEY                # Secret variable set in Travis CI
@@ -47,7 +47,7 @@ cache:
     - "$HOME/.cache/pip"
     - "$HOME/.gem/ruby"
     - "$HOME/Library/Caches/Homebrew" # (1)
-    - "$HOME/.cache/Homebrew"         # (2)
+    - "$HOME/.cache/Homebrew" # (2)
 
 install:
   # the official test-bot won't let you run inside TravisCI, so we use
@@ -66,10 +66,10 @@ install:
   # branch, and thus we cannot test our tap at the current pushed commit.
   # We also need to unshallow in 4) because sometimes travis does not
   # clone thouroughly but we need a deep clone.
-  - mkdir -p $(brew --repo $TRAVIS_REPO_SLUG)   # 1)
-  - rm -rf $(brew --repo $TRAVIS_REPO_SLUG)     # 2)
+  - mkdir -p $(brew --repo $TRAVIS_REPO_SLUG) # 1)
+  - rm -rf $(brew --repo $TRAVIS_REPO_SLUG) # 2)
   - ln -s $PWD $(brew --repo $TRAVIS_REPO_SLUG) # 3)
-  - git fetch --unshallow || true               # 4)
+  - git fetch --unshallow || true # 4)
   # Unless I am in 'brew test-bot', I don't want to fail on warnings.
   # perl regex: needed so that I can use 1.4.0-beta1 or 1.4.0-rc1 as stable versions
   - perl -pi -e 's/(.*)problem(.*version.*should not contain.*)$/$1opoo$2/' $(brew --repo)/Library/Homebrew/dev-cmd/audit.rb
@@ -95,12 +95,11 @@ jobs:
   include:
     - &run-osx
       os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       env: OS=high_sierra-10.13
       # We must use 'rvm: system' because the system ruby doesn't rely on
       # Homebrew, which allows us to reinstall Homebrew without having a
       # damaged ruby. We need ruby because we use the 'aws-sdk-s3' gem.
-      rvm: system
       before_install: # IMPORTANT: HOMEBREW_DEVELOPER must not be set here.
         # First we uninstall any outdated versions of xquartz; otherwise,
         # Homebrew will complain of of older version (2.9.7) being outdated
@@ -127,7 +126,7 @@ jobs:
           else travis_retry brew cask install xquartz --no-quarantine; fi
         # We still need the Homebrew ruby on macOS 10.12 and 10.11 because the
         # system ruby uses an old openssl version ("tlsv1 alert protocol").
-        - travis_retry brew install libyaml gmp openssl@1.1 openssl
+        - travis_retry brew install libyaml gmp openssl@1.1
     # TO BE ENABLED AS SOON AS TRAVIS HAS A MOJAVE IMAGE:
     #- <<: *run-osx
     #  os: osx
@@ -138,6 +137,11 @@ jobs:
       os: osx
       osx_image: xcode9.2
       env: OS=sierra-10.12
+
+    - <<: *run-osx
+      os: osx
+      osx_image: xcode10.2
+      env: OS=mojave-10.14
 
     - &run-on-linux
       os: linux
@@ -150,8 +154,8 @@ jobs:
         # Because we cannot do 'umask 002' just before travis clones the repo,
         # I set umask afterwards (1) and I change the permission of
         # already cloned files from 664 to 644 (2).
-        - umask 022          # (1)
-        - chmod 0644 *.rb    # (2)
+        - umask 022 # (1)
+        - chmod 0644 *.rb # (2)
 
         # Instal linuxbrew
         - export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH";
@@ -193,11 +197,11 @@ jobs:
         - |
           if ls *.{json,tar.gz}; then                                  # (1)
             sed -i 's:/usr/local:/home/linuxbrew/.linuxbrew:g' *.json; # (2)
-            ls *.high_sierra.bottle.json | while read json; do         # (3)
-              sed 's/high_sierra/mojave/g' $json > ${json/high_sierra/mojave};
-              bottle=`ls ${json/bottle*/}*.tar.gz`;
-              cp ${bottle} ${bottle/high_sierra/mojave};
-            done;
+            # ls *.high_sierra.bottle.json | while read json; do         # (3)
+            #   sed 's/high_sierra/mojave/g' $json > ${json/high_sierra/mojave};
+            #   bottle=`ls ${json/bottle*/}*.tar.gz`;
+            #   cp ${bottle} ${bottle/high_sierra/mojave};
+            # done;
             brew test-bot --ci-upload --root-url=$TAP_BOTTLE_ROOT_URL --git-name=$GITHUB_USER --git-email=mael.valais@gmail.com --bintray-org=$TAP_BOTTLE_ORG --verbose;
           else
             echo "==> No bottle found in the bucket, skipping --ci-upload";
@@ -205,6 +209,10 @@ jobs:
       after_script: true # nothing
 
 after_script:
+  # We still need the 'rvm default' ruby (which links to Homebrew stuff) on
+  # macOS 10.12 and 10.11 because the system ruby has an old openssl
+  # ("tlsv1 alert protocol"). Reinstall needed stuff removed by test-bot.
+  - travis_retry brew install libyaml gmp openssl@1.1
   # In case the AWS_SECRET_ACCESS_KEY and AWS_SECRET_ACCESS_KEY are not
   # available, we don't want the build to fail.
   # Here, the 'testing' jobs have finished and must upload their *.{json,tar.gz}
@@ -216,7 +224,6 @@ after_script:
 before_cache:
   # Scrub cache so that travis only caches stuff for installed formulae.
   - brew cleanup -s
-  - brew cask cleanup
   # Remove temporary stuff (idk why they put that in ~/.cache... that should be in /tmp)
   - rm -f ~/Library/Caches/Homebrew/linkage.db ~/.cache/Homebrew/linkage.db
   # List the formulae so that I understand why the cache is huge sometimes

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,11 @@ install:
   # the official test-bot won't let you run inside TravisCI, so we use
   # davidchall's one. David's test-bot cannot push the commit using
   # Oauth github + https (only ssh) so I use my own.
-  - brew tap maelvalais/test-bot
+  - brew tap maelvls/test-bot
   # Often, Travis CI image's git is too old for brew
   - brew install git
   # Install the ruby AWS gem so that I can upload bottles to S3
-  - rvm default do gem install aws-sdk-s3
+  - sudo gem install aws-sdk-s3
   # IMPORTANT STEP: link the tap inside brew to our current travis-cloned tap
   # Step: 1) create the intermediate folders <user>/<repo> so that
   # we can 2) remove <repo> and 3) replace it with a sym link
@@ -124,14 +124,10 @@ jobs:
           if [ -d ~/usr_local/Caskroom/xquartz ];
           then sudo mv ~/usr_local/Caskroom /usr/local/Caskroom;
           else travis_retry brew cask install xquartz --no-quarantine; fi
-        # We still need the Homebrew ruby on macOS 10.12 and 10.11 because the
-        # system ruby uses an old openssl version ("tlsv1 alert protocol").
+        # We still need the 'rvm default' ruby (which links to Homebrew stuff) on
+        # macOS 10.12 and 10.11 because the system ruby has an old openssl
+        # ("tlsv1 alert protocol"). Reinstall needed stuff removed by test-bot.
         - travis_retry brew install libyaml gmp openssl@1.1
-    # TO BE ENABLED AS SOON AS TRAVIS HAS A MOJAVE IMAGE:
-    #- <<: *run-osx
-    #  os: osx
-    #  osx_image: xcode9.4
-    #  env: OS=high_sierra-10.13
 
     - <<: *run-osx
       os: osx

--- a/qute.rb
+++ b/qute.rb
@@ -4,7 +4,7 @@ class Qute < Formula
   url "https://github.com/maelvalais/qute/archive/v0.0.1.tar.gz"
   sha256 "488825160ac586df7c0c642fff673731ba82647defa12941acde93bcf503a7d8"
   head "https://github.com/maelvalais/qute.git"
-  revision 5
+  revision 6
 
   bottle do
     root_url "https://dl.bintray.com/touist/bottles-touist"


### PR DESCRIPTION
```
==> /usr/local/Cellar/qute/0.0.1_5/bin/qute /private/tmp/qute-test-20190820-6859-1ole2ub/test.dimacs
dyld: lazy symbol binding failed: Symbol not found: __ZN5boost6detail12set_tss_dataEPKvNS_10shared_ptrINS0_20tss_cleanup_functionEEEPvb
  Referenced from: /usr/local/Cellar/qute/0.0.1_5/bin/qute
  Expected in: /usr/local/opt/boost/lib/libboost_thread-mt.dylib
dyld: Symbol not found: __ZN5boost6detail12set_tss_dataEPKvNS_10shared_ptrINS0_20tss_cleanup_functionEEEPvb
  Referenced from: /usr/local/Cellar/qute/0.0.1_5/bin/qute
  Expected in: /usr/local/opt/boost/lib/libboost_thread-mt.dylib
Error: qute: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: <10> expected but was
<nil>.
```